### PR TITLE
Some small path fixes

### DIFF
--- a/checkpoints/download.sh
+++ b/checkpoints/download.sh
@@ -7,6 +7,8 @@ mkdir trancos_ResFCN
 unzip trancos_ResFCN.zip -d trancos_ResFCN
 rm trancos_ResFCN.zip
 mv trancos_ResFCN/State_Dicts/best_model.pth best_model_trancos_ResFCN.pth
+mv trancos_ResFCN/history.json history_trancos_ResFCN.json
+rm -r trancos_ResFCN
 
 # Download Pascal checkpoint
 curl -L https://www.dropbox.com/sh/pwmoej499sfqb08/AABY13YraHYF51yw62Zc1w0-a?dl=0 > pascal_ResFCN.zip
@@ -14,7 +16,8 @@ mkdir pascal_ResFCN
 unzip pascal_ResFCN.zip -d pascal_ResFCN
 rm pascal_ResFCN.zip
 mv pascal_ResFCN/State_Dicts/best_model.pth best_model_pascal_ResFCN.pth
-
+mv pascal_ResFCN/history.json history_pascal_ResFCN.json
+rm -r pascal_ResFCN
 
 # # Download Shanghai checkpoint
 # curl -L https://www.dropbox.com/sh/pwmoej499sfqb08/AABY13YraHYF51yw62Zc1w0-a?dl=0 > pascal_ResFCN.zip

--- a/datasets/trancos.py
+++ b/datasets/trancos.py
@@ -18,8 +18,8 @@ class Trancos(data.Dataset):
         self.transform_function = transform_function
         
         ############################
-        # self.path_base = "datasets/TRANCOS_v3/"
-        self.path_base = "/mnt/datasets/public/issam/Trancos/"
+        self.path_base = "datasets/TRANCOS_v3/"
+        # self.path_base = "/mnt/datasets/public/issam/Trancos/"
 
         if split == "train":
             fname = self.path_base + "/image_sets/training.txt"

--- a/main.py
+++ b/main.py
@@ -14,7 +14,8 @@ def main():
   parser.add_argument('-image_path','--image_path', default=None)
   parser.add_argument('-model_path','--model_path', default=None)
   parser.add_argument('-model_name','--model_name', default=None)
-
+  parser.add_argument('-r', '--reset', action="store_const", const=True, default=False, help="If set, a new model will be created, overwriting any previous version.")
+  
   args = parser.parse_args()
 
   dataset_name, model_name, metric_name = experiments.get_experiment(args.exp_name)
@@ -32,7 +33,7 @@ def main():
     applyOnImage.apply(args.image_path, args.model_name, args.model_path)
 
   elif args.mode == "train":
-    train.train(dataset_name, model_name, metric_name, path_history, path_model, path_opt, path_best_model,)
+    train.train(dataset_name, model_name, metric_name, path_history, path_model, path_opt, path_best_model, args.reset)
 
   elif args.mode == "test":
     test.test(dataset_name, model_name, metric_name, path_history, path_best_model)

--- a/main.py
+++ b/main.py
@@ -1,7 +1,7 @@
 import matplotlib
 matplotlib.use('Agg')
 import os
-os.environ["CUDA_VISIBLE_DEVICES"]="7"
+#os.environ["CUDA_VISIBLE_DEVICES"]="7"
 
 import argparse
 import applyOnImage


### PR DESCRIPTION
This small change is to fix some "Not Found" errors that occur when running `python main.py -m summary -e trancos` or `python main.py -m test -e trancos`. I have also added a `--reset` commandline argument to `main.py` that allows one to reset the training even if the model already exists.