### PR TITLE
Change `np.all` to `torch.tensor.all`

### DIFF
--- a/datasets/trancos.py
+++ b/datasets/trancos.py
@@ -60,7 +60,7 @@ class Trancos(data.Dataset):
         if self.transform_function is not None:
             image, points = self.transform_function(collection)
             
-        if np.all(points == -1):
+        if (points == -1).all():
             pass
         else:
             assert int(points.sum()) == counts[0]


### PR DESCRIPTION
This is a proposed change from `np.all()` to `torch.tensor.all()` in `datasets/trancos.py`. I don't know if it is necessary, but it seems like it shouldn't break anything, and it does get rid of the following error for me when running `python main.py -m train -e trancos -r`:
```
Model: ResFCN - Dataset: trancos - Metric: MAE
Starting from scratch...
Training Epoch 1 .... 403 batches
Traceback (most recent call last):
  File "main.py", line 45, in <module>
    main()
  File "main.py", line 36, in main
    train.train(dataset_name, model_name, metric_name, path_history, path_model, path_opt, path_best_model, args.reset)
  File "/home/mlaradji/projects/ElementAI/LCFCN/train.py", line 76, in train
    epoch=epoch)
  File "/home/mlaradji/projects/ElementAI/LCFCN/utils.py", line 28, in fit
    for i, batch in enumerate(dataloader):
  File "/home/mlaradji/.conda/envs/LCFCN/lib/python3.6/site-packages/torch/utils/data/dataloader.py", line 615, in __next__
    batch = self.collate_fn([self.dataset[i] for i in indices])
  File "/home/mlaradji/.conda/envs/LCFCN/lib/python3.6/site-packages/torch/utils/data/dataloader.py", line 615, in <listcomp>
    batch = self.collate_fn([self.dataset[i] for i in indices])
  File "/home/mlaradji/projects/ElementAI/LCFCN/datasets/trancos.py", line 63, in __getitem__
    if np.all(points == -1):
  File "/home/mlaradji/.local/lib/python3.6/site-packages/numpy/core/fromnumeric.py", line 2089, in all
    return _wrapreduction(a, np.logical_and, 'all', axis, None, out, keepdims=keepdims)
  File "/home/mlaradji/.local/lib/python3.6/site-packages/numpy/core/fromnumeric.py", line 81, in _wrapreduction
    return reduction(axis=axis, out=out, **passkwargs)
TypeError: all() missing 1 required positional arguments: "dim"
```

According to   [this](https://github.com/pytorch/pytorch/issues/2481), `torch.tensor.all` is apparently not well-documented but it exists.